### PR TITLE
Change parameter name to reflect the use of AFREQ file

### DIFF
--- a/Software/model_prediction/matchGenotypeModel.R
+++ b/Software/model_prediction/matchGenotypeModel.R
@@ -12,9 +12,9 @@ parser$add_argument(
 )
 
 parser$add_argument(
-  "--snpStatsFile",
+  "--aFreqFile",
   type = "character",
-  help = "Full path to the output of qctool until \"chr\""
+  help = "Full path to the AFREQ file until \"chr\""
 )
 
 parser$add_argument(


### PR DESCRIPTION
Fix parameter name to support the change from the use of SNP_STATS to AFREQ file