### PR TITLE
Make computing pathway scores optional

### DIFF
--- a/Software/model_prediction/Tscore_PathScore_diff_run.R
+++ b/Software/model_prediction/Tscore_PathScore_diff_run.R
@@ -325,214 +325,212 @@ colnames(tscoreTables[[1]])[-1] <- mapply(function(x,y) paste(x, y),x= sampleAnn
 #################################################
 #################### Reactome ###################
 #################################################
+if (!is.null(reactome_file)) {
+  gs <- readGmt(reactome_file)
+  geneSetName="Reactome"
 
-gs <- readGmt(reactome_file)
-geneSetName="Reactome"
-
-gs=lapply(gs,function(X){
-  X@ids=gsub(",1.0","",X@ids)
-  return(X)
-})
-
-# lineage scorecard settings
-minGenesPerGeneSet = 1
-maxGenesPerGeneSet = 50000
-# perform parametric gene set analysis on the moderated t statistics that compare each sample with the reference
-performClustering = F
-pvalScorecard = F
-maxGeneSetsPlotted = 100
-curGeneSets = gs #scorecardGeneSets
-scorecards = list()
-
-i=1
-curComparison = names(tscoreTables)[i]
-tTable = tscoreTables[[i]]
-geneNames=tTable[,1]
-print(paste("Processing:",curComparison))
-# prepare data for PGSEA analysis
-tCols = names(tTable)[grep(":: t",names(tTable))]
-exprs = as.matrix(tTable[,tCols])
-exprs=exprs[,colSums(is.nan(exprs))==0] # where the NaNs come from?
-dimnames(exprs)[[1]] = geneNames
-curColNames = sapply(dimnames(exprs)[[2]],function(X) { gsub(" vs.*$","",X)  }); names(curColNames) = NULL
-dimnames(exprs)[[2]] = curColNames
-geneSetNames = sapply(curGeneSets,function(X) { X@reference })
-names(geneSetNames) = NULL    
-geneSetLengths = sapply(curGeneSets,function(X) { length(X@ids) })
-names(geneSetLengths) = NULL    
-# perform PGSEA analysis on the t-scores relative to the reference and subsequently filter out those gene sets that do not fall within the size range
-results = modPGSEA(exprs, curGeneSets, range=c(minGenesPerGeneSet, maxGenesPerGeneSet), center=F, p.value=T) 
-scores = results[["results"]]; dimnames(scores) = list(geneSetNames,gsub("\\.t","",dimnames(scores)[[2]]))
-pvalues = results[["p.results"]]; dimnames(pvalues) = list(geneSetNames,paste("pval",gsub("\\.t",".pval",dimnames(pvalues)[[2]]),sep="_"))
-valid = apply(scores,1,function(X) { sum(is.na(X)) == 0 })
-insufficientCoverage = paste(geneSetNames[!valid])
-scores = scores[valid,]
-pvalues = pvalues[valid,]
-# for each lineage / group of gene sets, take the mean of the gene set scores of all contributing gene sets
-# export lineage scorecard
-output = data.frame(rownames(scores),scores)
-names(output) = c("pathID",colnames(scores))
-output2 = data.frame(rownames(scores),pvalues)
-names(output2) = c("pathID",colnames(pvalues))
-write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)     
-write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)      
-scorecards[[curComparison]] = output
-
-sigScores = scores; #sigScores[pvalues>0.005] = NA
-if(any(sampleAnn$Dx == 1)){
-  
-  cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
-  pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
-  # save
-  write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))), 
-              file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-}
-
-controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
-pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
-# save
-write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))), 
-            file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-
-
-
-
-if(any(sampleAnn$Dx == 1)){
-  
-  thres=0.05
-  rAll=rowSums(pvalues<=thres)
-  rCase=rowSums(pvalues[,cases]<=thres)
-  rFrac=rCase/rAll
-  ind=!is.nan(rFrac)
-  pEn=cbind(rAll,rCase,rFrac)
-  
-  write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-              sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
-  
-  padj=apply(pvalues,2,function(X){
-    return(qvalue(X)$qvalue)
+  gs=lapply(gs,function(X){
+    X@ids=gsub(",1.0","",X@ids)
+    return(X)
   })
-  
-  #find gene sets that show high deviation
-  thres=0.05
-  rAll=rowSums(padj<=thres)
-  rCase=rowSums(padj[,cases]<=thres)
-  # rAll=rowSums(pvalues<=thres)
-  # rCase=rowSums(pvalues[,cases]<=thres)
-  
-  
-  rFrac=rCase/rAll
-  ind=!is.nan(rFrac)
-  pEn=cbind(rAll,rCase,rFrac)
-  
-  write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-              sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
-  
-  
-}
 
+  # lineage scorecard settings
+  minGenesPerGeneSet = 1
+  maxGenesPerGeneSet = 50000
+  # perform parametric gene set analysis on the moderated t statistics that compare each sample with the reference
+  performClustering = F
+  pvalScorecard = F
+  maxGeneSetsPlotted = 100
+  curGeneSets = gs #scorecardGeneSets
+  scorecards = list()
+
+  i=1
+  curComparison = names(tscoreTables)[i]
+  tTable = tscoreTables[[i]]
+  geneNames=tTable[,1]
+  print(paste("Processing:",curComparison))
+  # prepare data for PGSEA analysis
+  tCols = names(tTable)[grep(":: t",names(tTable))]
+  exprs = as.matrix(tTable[,tCols])
+  exprs=exprs[,colSums(is.nan(exprs))==0] # where the NaNs come from?
+  dimnames(exprs)[[1]] = geneNames
+  curColNames = sapply(dimnames(exprs)[[2]],function(X) { gsub(" vs.*$","",X)  }); names(curColNames) = NULL
+  dimnames(exprs)[[2]] = curColNames
+  geneSetNames = sapply(curGeneSets,function(X) { X@reference })
+  names(geneSetNames) = NULL
+  geneSetLengths = sapply(curGeneSets,function(X) { length(X@ids) })
+  names(geneSetLengths) = NULL
+  # perform PGSEA analysis on the t-scores relative to the reference and subsequently filter out those gene sets that do not fall within the size range
+  results = modPGSEA(exprs, curGeneSets, range=c(minGenesPerGeneSet, maxGenesPerGeneSet), center=F, p.value=T)
+  scores = results[["results"]]; dimnames(scores) = list(geneSetNames,gsub("\\.t","",dimnames(scores)[[2]]))
+  pvalues = results[["p.results"]]; dimnames(pvalues) = list(geneSetNames,paste("pval",gsub("\\.t",".pval",dimnames(pvalues)[[2]]),sep="_"))
+  valid = apply(scores,1,function(X) { sum(is.na(X)) == 0 })
+  insufficientCoverage = paste(geneSetNames[!valid])
+  scores = scores[valid,]
+  pvalues = pvalues[valid,]
+  # for each lineage / group of gene sets, take the mean of the gene set scores of all contributing gene sets
+  # export lineage scorecard
+  output = data.frame(rownames(scores),scores)
+  names(output) = c("pathID",colnames(scores))
+  output2 = data.frame(rownames(scores),pvalues)
+  names(output2) = c("pathID",colnames(pvalues))
+  write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)
+  write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
+  scorecards[[curComparison]] = output
+
+  sigScores = scores; #sigScores[pvalues>0.005] = NA
+  if(any(sampleAnn$Dx == 1)){
+
+    cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
+    pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
+    # save
+    write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))),
+                file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
+  }
+
+  controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
+  pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
+  # save
+  write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))),
+              file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
+
+
+
+
+  if(any(sampleAnn$Dx == 1)){
+
+    thres=0.05
+    rAll=rowSums(pvalues<=thres)
+    rCase=rowSums(pvalues[,cases]<=thres)
+    rFrac=rCase/rAll
+    ind=!is.nan(rFrac)
+    pEn=cbind(rAll,rCase,rFrac)
+
+    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
+                sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
+
+    padj=apply(pvalues,2,function(X){
+      return(qvalue(X)$qvalue)
+    })
+
+    #find gene sets that show high deviation
+    thres=0.05
+    rAll=rowSums(padj<=thres)
+    rCase=rowSums(padj[,cases]<=thres)
+    # rAll=rowSums(pvalues<=thres)
+    # rCase=rowSums(pvalues[,cases]<=thres)
+
+
+    rFrac=rCase/rAll
+    ind=!is.nan(rFrac)
+    pEn=cbind(rAll,rCase,rFrac)
+
+    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
+                sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
+
+
+  }
+}
 
 ################################################
 #################### GO term ###################
 ################################################
 
 # repeat the same for GO terms
-go <- get(load(GOterms_file))
-geneSetName <- 'GO'
-# lineage scorecard settings
-minGenesPerGeneSet = 1
-maxGenesPerGeneSet = 50000
-# perform parametric gene set analysis on the moderated t statistics that compare each sample with the reference
-performClustering = F
-pvalScorecard = F
-maxGeneSetsPlotted = 100
-#curGeneSets = allGeneSets
-scorecards = list()
+if (!is.null(GOterms_file)) {
+  go <- get(load(GOterms_file))
+  geneSetName <- 'GO'
+  # lineage scorecard settings
+  minGenesPerGeneSet = 1
+  maxGenesPerGeneSet = 50000
+  # perform parametric gene set analysis on the moderated t statistics that compare each sample with the reference
+  performClustering = F
+  pvalScorecard = F
+  maxGeneSetsPlotted = 100
+  #curGeneSets = allGeneSets
+  scorecards = list()
 
-i=1
-curComparison = names(tscoreTables)[i]
-tTable = tscoreTables[[i]]
-geneNames=tTable[,1]
-print(paste("Processing:",curComparison))
-# prepare data for PGSEA analysis
-tCols = names(tTable)[grep(":: t",names(tTable))]
-exprs = as.matrix(tTable[,tCols])
-exprs=exprs[,colSums(is.nan(exprs))==0] # where the NaNs come from?
-dimnames(exprs)[[1]] = geneNames
-curColNames = sapply(dimnames(exprs)[[2]],function(X) { gsub(" vs.*$","",X)  }); names(curColNames) = NULL
-dimnames(exprs)[[2]] = curColNames
+  i=1
+  curComparison = names(tscoreTables)[i]
+  tTable = tscoreTables[[i]]
+  geneNames=tTable[,1]
+  print(paste("Processing:",curComparison))
+  # prepare data for PGSEA analysis
+  tCols = names(tTable)[grep(":: t",names(tTable))]
+  exprs = as.matrix(tTable[,tCols])
+  exprs=exprs[,colSums(is.nan(exprs))==0] # where the NaNs come from?
+  dimnames(exprs)[[1]] = geneNames
+  curColNames = sapply(dimnames(exprs)[[2]],function(X) { gsub(" vs.*$","",X)  }); names(curColNames) = NULL
+  dimnames(exprs)[[2]] = curColNames
 
-geneSetNames = sapply(go,function(X) { X$GOID })
-geneSetLengths = sapply(go,function(X) { length(unique(X$geneIds))})
+  geneSetNames = sapply(go,function(X) { X$GOID })
+  geneSetLengths = sapply(go,function(X) { length(unique(X$geneIds))})
 
-# perform PGSEA analysis on the t-scores relative to the reference and subsequently filter out those gene sets that do not fall within the size range
-results = modPGSEA(exprs, go, range=c(minGenesPerGeneSet, maxGenesPerGeneSet), center=F, p.value=T) 
-scores = results[["results"]]; dimnames(scores) = list(geneSetNames,gsub("\\.t","",dimnames(scores)[[2]]))
-pvalues = results[["p.results"]]; dimnames(pvalues) = list(geneSetNames,paste("pval",gsub("\\.t",".pval",dimnames(pvalues)[[2]]),sep="_"))
-valid = apply(scores,1,function(X) { sum(is.na(X)) == 0 })
-insufficientCoverage = paste(geneSetNames[!valid])
-scores = scores[valid,]
-pvalues = pvalues[valid,]
-# for each lineage / group of gene sets, take the mean of the gene set scores of all contributing gene sets
-# export lineage scorecard
-output = data.frame(rownames(scores),scores)
-names(output) = c("pathID",colnames(scores))
-output2 = data.frame(rownames(scores),pvalues)
-names(output2) = c("pathID",colnames(pvalues))
-write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)     
-write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)      
-scorecards[[curComparison]] = output
+  # perform PGSEA analysis on the t-scores relative to the reference and subsequently filter out those gene sets that do not fall within the size range
+  results = modPGSEA(exprs, go, range=c(minGenesPerGeneSet, maxGenesPerGeneSet), center=F, p.value=T)
+  scores = results[["results"]]; dimnames(scores) = list(geneSetNames,gsub("\\.t","",dimnames(scores)[[2]]))
+  pvalues = results[["p.results"]]; dimnames(pvalues) = list(geneSetNames,paste("pval",gsub("\\.t",".pval",dimnames(pvalues)[[2]]),sep="_"))
+  valid = apply(scores,1,function(X) { sum(is.na(X)) == 0 })
+  insufficientCoverage = paste(geneSetNames[!valid])
+  scores = scores[valid,]
+  pvalues = pvalues[valid,]
+  # for each lineage / group of gene sets, take the mean of the gene set scores of all contributing gene sets
+  # export lineage scorecard
+  output = data.frame(rownames(scores),scores)
+  names(output) = c("pathID",colnames(scores))
+  output2 = data.frame(rownames(scores),pvalues)
+  names(output2) = c("pathID",colnames(pvalues))
+  write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)
+  write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
+  scorecards[[curComparison]] = output
 
-sigScores = scores; #sigScores[pvalues>0.005] = NA
-if(any(sampleAnn$Dx == 1)){
-  
-  cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
-  pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
+  sigScores = scores; #sigScores[pvalues>0.005] = NA
+  if(any(sampleAnn$Dx == 1)){
+
+    cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
+    pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
+    # save
+    write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))),
+                file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
+  }
+
+  controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
+  pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
   # save
-  write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))), 
-              file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
+  write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))),
+              file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
+
+
+
+  if(any(sampleAnn$Dx == 1)){
+
+    thres=0.05
+    rAll=rowSums(pvalues<=thres)
+    rCase=rowSums(pvalues[,cases]<=thres)
+    rFrac=rCase/rAll
+    ind=!is.nan(rFrac)
+    pEn=cbind(rAll,rCase,rFrac)
+
+    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
+                sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
+
+    padj=apply(pvalues,2,function(X){
+      return(qvalue(X)$qvalue)
+    })
+
+    #find gene sets that show high deviation
+    thres=0.05
+    rAll=rowSums(padj<=thres)
+    rCase=rowSums(padj[,cases]<=thres)
+    # rAll=rowSums(pvalues<=thres)
+    # rCase=rowSums(pvalues[,cases]<=thres)
+
+
+    rFrac=rCase/rAll
+    ind=!is.nan(rFrac)
+    pEn=cbind(rAll,rCase,rFrac)
+
+    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
+                sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
+  }
 }
-
-controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
-pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
-# save
-write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))), 
-            file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-
-
-
-if(any(sampleAnn$Dx == 1)){
-  
-  thres=0.05
-  rAll=rowSums(pvalues<=thres)
-  rCase=rowSums(pvalues[,cases]<=thres)
-  rFrac=rCase/rAll
-  ind=!is.nan(rFrac)
-  pEn=cbind(rAll,rCase,rFrac)
-  
-  write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-              sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
-  
-  padj=apply(pvalues,2,function(X){
-    return(qvalue(X)$qvalue)
-  })
-  
-  #find gene sets that show high deviation
-  thres=0.05
-  rAll=rowSums(padj<=thres)
-  rCase=rowSums(padj[,cases]<=thres)
-  # rAll=rowSums(pvalues<=thres)
-  # rCase=rowSums(pvalues[,cases]<=thres)
-  
-  
-  rFrac=rCase/rAll
-  ind=!is.nan(rFrac)
-  pEn=cbind(rAll,rCase,rFrac)
-  
-  write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-              sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
-  
-  
-}
-
-

--- a/Software/model_prediction/pheno_association_metaAnalysis_noPathScore_run.R
+++ b/Software/model_prediction/pheno_association_metaAnalysis_noPathScore_run.R
@@ -179,9 +179,7 @@ for(j in 1:length(pheno_var)){
   
 }  
 
-final <- list(pheno = res$pheno, tscore = df_tscore_all,,pi1_lambdafixed = df_pi1)
+final <- list(pheno = res$pheno, tscore = df_tscore_all, pi1_lambdafixed = df_pi1)
 
 file_name <- ifelse(cov_corr,sprintf('%spval_%s_pheno_covCorr.RData', outFold, phenoName), sprintf('%spval_%s_pheno.RData', outFold, phenoName))
 save(final, file = file_name)
-
-

--- a/Software/model_prediction/pheno_association_metaAnalysis_noPathScore_run.R
+++ b/Software/model_prediction/pheno_association_metaAnalysis_noPathScore_run.R
@@ -1,0 +1,187 @@
+#!/usr/bin/env Rscript
+# meta - analysis across different cohorts
+
+options(stringsAsFactors=F)
+options(max.print=1000)
+suppressPackageStartupMessages(library(argparse))
+suppressPackageStartupMessages(library(qvalue))
+suppressPackageStartupMessages(library(biomaRt))
+
+
+parser <- ArgumentParser(description="Meta analysis tscore and pathway scores")
+parser$add_argument("--res_cohorts", type="character", nargs = '*', help = "RData file with the phenotype association results")
+parser$add_argument("--phenoDatFile_cohorts", type="character", nargs = '*', help = "file with the phenotype info for each cohort")
+parser$add_argument("--name_cohort", type="character", nargs = '*', help = "names of the cohorts")
+parser$add_argument("--cov_corr", type = "logical", default = T,  help = "if T column in covDat_file are use to correct association (excluded Dx and IDs) [default %(default)s]")
+parser$add_argument("--phenoName", type="character",  help = "phenotype group name considered")
+parser$add_argument("--thr_het", type = "double", default = 0.001, help = "threshold for random effect model [default %(default)s]")
+parser$add_argument("--outFold", type="character", help = "Output file [basename only]")
+
+args <- parser$parse_args()
+res_cohorts <- args$res_cohorts
+name_cohort <- args$name_cohort
+phenoDatFile_cohorts <- args$phenoDatFile_cohorts
+cov_corr <- args$cov_corr
+phenoName <- args$phenoName
+thr_het <- args$thr_het
+outFold <- args$outFold
+
+###########################################################################################
+# res_cohorts <- sapply(c('CG','LURIC', 'WTCCC', 'MG', paste0('German', 1:5)) , function(x) sprintf('OUTPUT_GTEx/predict_CAD/Adipose_Subcutaneous/200kb/CAD_GWAS_bin5e-2/%s/devgeno0.01_testdevgeno0/pval_CAD_pheno_covCorr.RData', x))
+# name_cohort <- c('CG','LURIC', 'WTCCC', 'MG', paste0('German', 1:5))
+# phenoDatFile_cohorts <- sapply(c('CG','LURIC', 'WTCCC', 'MG',paste0('German', 1:5)) , function(x) sprintf('INPUT_DATA_GTEx/CAD/Covariates/%s/phenoMatrix.txt', x))
+# cov_corr = T
+# thr_het <- 10^-3
+# phenoName <- 'Dx'
+# lambda_pi1 <- 0.5
+# GOterms_file <- '/psycl/g/mpsziller/lucia/refData/GOterm_geneAnnotation_allOntologies.RData'
+# reactome_file <- '/psycl/g/mpsziller/lucia/refData/ReactomePathways.gmt'
+# outFold <- 'OUTPUT_GTEx/predict_CAD/Adipose_Subcutaneous/200kb/CAD_GWAS_bin5e-2/Meta_Analysis_CAD/'
+################################################################################################################################
+
+
+# make a list of all the possible phenotype to consider + summary samples
+pheno_tab <- list()
+df_len_pheno <- list()
+for(i in 1:length(phenoDatFile_cohorts)){
+  
+  # note: some phenotype were previously removed for missingness
+  pheno_tab[[i]] <- read.table(phenoDatFile_cohorts[i], h=T, stringsAsFactors = F, sep = '\t')
+ 
+  len_pheno_single <- rep(1, ncol(pheno_tab[[i]])-1)
+  
+  type_val <- apply(as.matrix(pheno_tab[[i]][, -1], ncol = len_pheno_single), 2, function(x) length(unique(x[!is.na(x)])))
+ 
+  type <- rep('binomial', length(type_val))
+  type[type_val>10] <- 'gaussian'
+  type[type_val<=10 & type_val>2] <- 'gaussian'
+ 
+  
+  df_len_pheno[[i]] <- data.frame(pheno = colnames(pheno_tab[[i]])[-1], len_pheno = len_pheno_single, type = type, cohort = name_cohort[i])
+  pheno_tab[[i]]$cohort <- name_cohort[i]
+  
+}
+
+# find phenotype that are in common and have the same amount of info
+df_len_pheno <- do.call(rbind, df_len_pheno)
+
+# summary pheno with number of cohorts
+df_pheno_tot <- data.frame(pheno = unique(df_len_pheno$pheno), n_studies = NA, cohort = NA, n_samples = NA, n_cases = NA, n_controls = NA, type = NA, binom_0 = NA, binom_1 = NA)
+for(i in 1:nrow(df_pheno_tot)){
+  
+  tmp <- df_len_pheno[df_len_pheno$pheno ==  df_pheno_tot$pheno[i],] 
+  df_pheno_tot$n_studies[i] <- nrow(tmp)
+  
+  if(length(unique(tmp$len_pheno))>1 | length(unique(tmp$type))>1){
+    df_pheno_tot$cohort[i] <- 'remove_inconsistent'
+  }else{
+    df_pheno_tot$type[i] <- unique(tmp$type)
+    df_pheno_tot$cohort[i] <- paste(tmp$cohort, collapse = '_')
+    id <- lapply(pheno_tab, function(x) !is.na(x[, colnames(x) %in% df_pheno_tot$pheno[i]]))
+    df_pheno_tot$n_samples[i] <- sum(sapply(pheno_tab, function(x) length(na.omit(x[, colnames(x) %in% df_pheno_tot$pheno[i]]))))
+    df_pheno_tot$n_cases[i] <- sum(mapply(function(x,y) length(which(x$Dx[y] == 1)), x = pheno_tab, y = id))
+    df_pheno_tot$n_controls[i] <- sum(mapply(function(x,y) length(which(x$Dx[y] == 0)), x = pheno_tab, y = id))
+    
+    df_pheno_tot$binom_1[i] <- sum(mapply(function(x,y) length(which(x[y, df_pheno_tot$pheno[i]] == 1)), x = pheno_tab, y = id))
+    df_pheno_tot$binom_0[i] <- sum(mapply(function(x,y) length(which(x[y, df_pheno_tot$pheno[i]] == 0)), x = pheno_tab, y = id))
+    
+  }
+}
+
+# save table
+file_name <- sprintf('%sphenoInfo_%s_cohorts.txt', outFold, phenoName)
+write.table(df_pheno_tot, file = file_name, col.names = T, row.names = F, sep = '\t', quote = F)
+
+#####################################################################################################
+## extraxt pval for each phenotype that have more tha 1 cohort or is not insonsistent
+id_pheno <- which(df_pheno_tot$n_studies > 1 & df_pheno_tot$cohort != 'remove_inconsistent')
+pheno_var <- lapply(id_pheno, function(x) list(pheno = 0, cohorts = 0))
+for(i in 1:length(id_pheno)){
+  
+  pheno_var[[i]]$pheno <- df_pheno_tot$pheno[id_pheno[i]]
+  pheno_var[[i]]$cohorts <- name_cohort[sapply(name_cohort, function(x) grepl(x,df_pheno_tot$cohort[id_pheno[i]]))]
+  
+}
+
+tmp_tscore <- list()
+
+for(i in 1:length(res_cohorts)){
+  res <- get(load(res_cohorts[[i]]))
+  tmp_tscore[[i]] <- list()
+  
+  for(j in 1:length(pheno_var)){
+    tmp_tscore[[i]][[j]] <- res$tscore[[j]]
+    tmp_tscore[[i]][[j]]$cohort <- pheno_var[[j]]$cohorts[i]
+  }
+}
+
+df_tscore_cohorts <- list()
+
+for(j in 1:length(pheno_var)){
+  df_tscore_cohorts[[j]] <- do.call(rbind, lapply(tmp_tscore, function(x) x[[j]]))
+}
+
+rm(tmp_tscore)
+
+
+df_tscore_all <- list()
+df_pi1 <-  data.frame(pheno_id =sapply(pheno_var, function(x) x$pheno),  tscore=0, pathScore_reactome=0,  pathScore_GO=0, stringsAsFactors = F)
+
+# for each phenotype considered
+for(j in 1:length(pheno_var)){
+  
+  # find only genes/pathway in common (deletion could have happend during pvalue computation)
+  #### tscores ####
+  
+  print(paste('##########', pheno_var[[j]]$pheno, '##########'))
+  
+  common_genes <- names(which(table(df_tscore_cohorts[[j]]$ensembl_gene_id) == length(pheno_var[[j]]$cohorts)))
+  df_tscore_cohorts[[j]] <- df_tscore_cohorts[[j]][df_tscore_cohorts[[j]]$ensembl_gene_id %in% common_genes, ]
+  info_tscore <- df_tscore_cohorts[[j]][!duplicated(df_tscore_cohorts[[j]]$ensembl_gene_id), c('ensembl_gene_id', 'external_gene_name','dev_geno', 'test_dev_geno')]
+  df_tscore_all[[j]] <- cbind(info_tscore, matrix(0, nrow = nrow(info_tscore), ncol = 9))
+  colnames(df_tscore_all[[j]])[-(1:4)] <- paste0(pheno_var[[j]]$pheno, c('_beta', '_se_beta', '_z', '_pval', '_qval', '_pval_BHcorr','_Cochran_stat', '_Cochran_pval', '_model'))
+  
+  for(i in 1:nrow(info_tscore)){
+    
+    if(i%%100 == 0){print(paste('gene', i))}
+    
+    model <- 'fixed'
+    tmp <- df_tscore_cohorts[[j]][df_tscore_cohorts[[j]]$ensembl_gene_id %in% info_tscore$ensembl_gene_id[i],]
+    w <- 1/(tmp[, sprintf('%s_se_beta', pheno_var[[j]]$pheno)])^2
+    beta_all <- sum(tmp[, sprintf('%s_beta', pheno_var[[j]]$pheno)]*w)/sum(w)
+    se_all <- sqrt(1/sum(w))
+    z_all <- beta_all/se_all
+    # p_all <- (1 - pnorm(abs(z_all), 0, 1)) * 2 # rounding approximation! use negative values
+    p_all <- 2*pnorm(-abs(z_all), 0,1)
+    Q <- sum(w*((beta_all - tmp[, sprintf('%s_beta', pheno_var[[j]]$pheno)])^2))
+    Q_pval <- pchisq(Q, df=nrow(tmp)-1, lower.tail=FALSE) # null hypothesis consistency
+    
+    if(Q_pval<=thr_het){
+      
+      tau2 <- max(0, (Q-nrow(tmp)+1)/(sum(w) - (sum(w^2)/sum(w))))
+      w_new <- 1/(tau2 + (tmp[, sprintf('%s_se_beta', pheno_var[[j]]$pheno)])^2)
+      se_all <- sqrt(1/sum(w_new))
+      beta_all <- sum(tmp[, sprintf('%s_beta', pheno_var[[j]]$pheno)]*w_new)/sum(w_new)
+      z_all <- beta_all/se_all
+      # p_all <- (1 - pnorm(abs(z_all), 0, 1)) * 2 # rounding approximation! use negative values
+      p_all <- 2*pnorm(-abs(z_all), 0,1)
+      model <- 'random'
+    }
+    
+    df_tscore_all[[j]][i, paste0(pheno_var[[j]]$pheno, c('_beta', '_se_beta', '_z', '_pval', '_Cochran_stat', '_Cochran_pval'))] <- c(beta_all, se_all, z_all, p_all, Q, Q_pval)
+    df_tscore_all[[j]][i, paste0(pheno_var[[j]]$pheno, '_model')] <- model
+    
+  }
+  
+  df_tscore_all[[j]][, paste0(pheno_var[[j]]$pheno, '_qval')] <- qvalue(df_tscore_all[[j]][,paste0(pheno_var[[j]]$pheno, '_pval')])$qvalue
+  df_tscore_all[[j]][, paste0(pheno_var[[j]]$pheno, '_pval_BHcorr')] <- p.adjust(df_tscore_all[[j]][,paste0(pheno_var[[j]]$pheno, '_pval')], method = 'BH')
+  df_pi1$tscore[j] <- 1- pi0est(df_tscore_all[[j]][,paste0(pheno_var[[j]]$pheno, '_pval')], lambda = 0.5)$pi0
+  
+}  
+
+final <- list(pheno = res$pheno, tscore = df_tscore_all,,pi1_lambdafixed = df_pi1)
+
+file_name <- ifelse(cov_corr,sprintf('%spval_%s_pheno_covCorr.RData', outFold, phenoName), sprintf('%spval_%s_pheno.RData', outFold, phenoName))
+save(final, file = file_name)
+
+

--- a/Software/model_prediction/pheno_association_smallData_run.R
+++ b/Software/model_prediction/pheno_association_smallData_run.R
@@ -440,6 +440,7 @@ for(n in 1:length(phenoDat_file)){
     print('pathScore reactome completed')
   } else {
     df_corr_pathR <- data.frame()
+    info_pathR <- data.frame()
   }
   
   ##################################
@@ -495,6 +496,7 @@ for(n in 1:length(phenoDat_file)){
     print('pathScore go completed')
   } else {
     df_corr_pathGO <- data.frame()
+    info_pathGO <- data.frame()
   }
 
   ################################################################################################################################################################################

--- a/Software/model_prediction/pheno_association_smallData_run.R
+++ b/Software/model_prediction/pheno_association_smallData_run.R
@@ -377,7 +377,12 @@ for(n in 1:length(phenoDat_file)){
     df_corr_tscore[[j]] <- cbind(df_tscore_info, output)
     
     # qvalue:
-    qval <- qvalue(as.vector(df_corr_tscore[[j]][, names_df[j,4]]))
+    # Prevent qvalue error when estimating pi0 from few scores. See https://github.com/StoreyLab/edge/issues/13
+    if (nrow(df_corr_tscore[[j]]) > 100) {
+      qval <- qvalue(as.vector(df_corr_tscore[[j]][, names_df[j,4]]))
+    } else {
+      qval <- qvalue(as.vector(df_corr_tscore[[j]][, names_df[j,4]]), pi0 = 1)
+    }
     df_corr_tscore[[j]] <- cbind(df_corr_tscore[[j]], qval$qvalue)
     colnames(df_corr_tscore[[j]])[ncol(df_corr_tscore[[j]])] <-  names_df_qval[j]
     df_pi1$tscore[j] <- 1 - qval$pi0

--- a/Software/model_prediction/pheno_association_smallData_run.R
+++ b/Software/model_prediction/pheno_association_smallData_run.R
@@ -378,7 +378,7 @@ for(n in 1:length(phenoDat_file)){
     
     # qvalue:
     # Prevent qvalue error when estimating pi0 from few scores. See https://github.com/StoreyLab/edge/issues/13
-    if (nrow(df_corr_tscore[[j]]) > 100) {
+    if (nrow(df_corr_tscore[[j]]) > 200) {
       qval <- qvalue(as.vector(df_corr_tscore[[j]][, names_df[j,4]]))
     } else {
       qval <- qvalue(as.vector(df_corr_tscore[[j]][, names_df[j,4]]), pi0 = 1)

--- a/Software/model_prediction/pheno_association_smallData_run.R
+++ b/Software/model_prediction/pheno_association_smallData_run.R
@@ -132,159 +132,163 @@ print('Tscore mat loaded')
 ##################################
 #### load pathScore Reactome #####
 ##################################
-tmp <-  fread(sprintf('%sPathway_Reactome_scores.txt', inputFold), header = T, stringsAsFactors = F, sep = '\t', check.names = F, data.table = F)
-pathScoreID_reactome <- tmp[,1]
-tmp <- tmp[,-1]
-identical(colnames(tmp), samplesID_new) # same order samples
-pathScore_reactome <- as.matrix(t(tmp))
-rm(tmp)
+if (!is.null(reactome_file)) {
+  tmp <-  fread(sprintf('%sPathway_Reactome_scores.txt', inputFold), header = T, stringsAsFactors = F, sep = '\t', check.names = F, data.table = F)
+  pathScoreID_reactome <- tmp[,1]
+  tmp <- tmp[,-1]
+  identical(colnames(tmp), samplesID_new) # same order samples
+  pathScore_reactome <- as.matrix(t(tmp))
+  rm(tmp)
 
 
-# consider only pathaways that do not have gene repetition, on pathwayScoreID add gene info
-gs <- readGmt(reactome_file)
+  # consider only pathaways that do not have gene repetition, on pathwayScoreID add gene info
+  gs <- readGmt(reactome_file)
 
-gs=lapply(gs,function(X){
-  X@ids=gsub(",1.0","",X@ids)
-  return(X)
-})
-gs_name <- sapply(gs, function(x) x@reference)
-gs <- gs[which(gs_name %in% pathScoreID_reactome)]
-gs_name <- unname(sapply(gs, function(x) x@reference))
-identical(gs_name, pathScoreID_reactome)
-
-genes_path <- lapply(gs, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x@ids])
-ngenes_path <-  sapply(gs, function(x) length(unique(x@ids[x@ids != ""])))
-ngenes_tscore_path <- sapply(genes_path, length)
-
-# remove pathway with the same genes, recompute qvalue
-rm_path <- c()
-len <- c()
-for(i in 1:length(genes_path)){
-  # print(i)
-  id <- which(sapply(genes_path, function(x) all(genes_path[[i]] %in% x) & all(x %in% genes_path[[i]])))
-  len[i] <- length(id)
-  ngenes_tmp <- ngenes_path[id]
-  # take the one woth the lower amount of genes
-  rm_path <- c(rm_path, gs_name[id][-which.min(ngenes_tmp)])
-}
-
-rm_path <- unique(rm_path)
-id_rm <- which(pathScoreID_reactome %in% rm_path)
-if(length(id_rm)>0){
-  pathScore_reactome <- pathScore_reactome[,-id_rm]
-  pathScoreID_reactome <- pathScoreID_reactome[-id_rm]
-  gs <- gs[-id_rm]
+  gs=lapply(gs,function(X){
+    X@ids=gsub(",1.0","",X@ids)
+    return(X)
+  })
+  gs_name <- sapply(gs, function(x) x@reference)
+  gs <- gs[which(gs_name %in% pathScoreID_reactome)]
   gs_name <- unname(sapply(gs, function(x) x@reference))
   identical(gs_name, pathScoreID_reactome)
+
   genes_path <- lapply(gs, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x@ids])
-  ngenes_path <- ngenes_path[-id_rm]
-  ngenes_tscore_path <- ngenes_tscore_path[-id_rm]
-}
+  ngenes_path <-  sapply(gs, function(x) length(unique(x@ids[x@ids != ""])))
+  ngenes_tscore_path <- sapply(genes_path, length)
 
-# add number of genes info and mean test_dev_geno and dev_geno
-df_pathR_info <- data.frame(path = pathScoreID_reactome, ngenes_tscore = unname(ngenes_tscore_path), ngenes_path = unname(ngenes_path), stringsAsFactors = F)
-df_pathR_info$mean_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathR_info$sd_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathR_info$mean_test_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathR_info$sd_test_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
-
-# compute mean/sd correlation for the genes belonging to the pathway (based on tscore)
-df_pathR_info$mean_gene_corr <- NA
-df_pathR_info$sd_gene_corr <- NA
-
-for(i in 1:length(genes_path)){
-  
-  id <- which(genesID %in% genes_path[[i]])
-  
-  if(length(id)>1){
+  # remove pathway with the same genes, recompute qvalue
+  rm_path <- c()
+  len <- c()
+  for(i in 1:length(genes_path)){
     # print(i)
-    tmp <- cor(tscoreMat[,id])
-    tmp <- tmp[lower.tri(tmp, diag = F)]
-    df_pathR_info$mean_gene_corr[i] <- mean(tmp)
-    df_pathR_info$sd_gene_corr[i] <- sd(tmp)  
+    id <- which(sapply(genes_path, function(x) all(genes_path[[i]] %in% x) & all(x %in% genes_path[[i]])))
+    len[i] <- length(id)
+    ngenes_tmp <- ngenes_path[id]
+    # take the one woth the lower amount of genes
+    rm_path <- c(rm_path, gs_name[id][-which.min(ngenes_tmp)])
   }
-  
-}
 
-print('pathScore reactome mat loaded')
+  rm_path <- unique(rm_path)
+  id_rm <- which(pathScoreID_reactome %in% rm_path)
+  if(length(id_rm)>0){
+    pathScore_reactome <- pathScore_reactome[,-id_rm]
+    pathScoreID_reactome <- pathScoreID_reactome[-id_rm]
+    gs <- gs[-id_rm]
+    gs_name <- unname(sapply(gs, function(x) x@reference))
+    identical(gs_name, pathScoreID_reactome)
+    genes_path <- lapply(gs, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x@ids])
+    ngenes_path <- ngenes_path[-id_rm]
+    ngenes_tscore_path <- ngenes_tscore_path[-id_rm]
+  }
+
+  # add number of genes info and mean test_dev_geno and dev_geno
+  df_pathR_info <- data.frame(path = pathScoreID_reactome, ngenes_tscore = unname(ngenes_tscore_path), ngenes_path = unname(ngenes_path), stringsAsFactors = F)
+  df_pathR_info$mean_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathR_info$sd_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathR_info$mean_test_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathR_info$sd_test_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
+
+  # compute mean/sd correlation for the genes belonging to the pathway (based on tscore)
+  df_pathR_info$mean_gene_corr <- NA
+  df_pathR_info$sd_gene_corr <- NA
+
+  for(i in 1:length(genes_path)){
+
+    id <- which(genesID %in% genes_path[[i]])
+
+    if(length(id)>1){
+      # print(i)
+      tmp <- cor(tscoreMat[,id])
+      tmp <- tmp[lower.tri(tmp, diag = F)]
+      df_pathR_info$mean_gene_corr[i] <- mean(tmp)
+      df_pathR_info$sd_gene_corr[i] <- sd(tmp)
+    }
+
+  }
+
+  print('pathScore reactome mat loaded')
+}
 
 ############################
 #### load pathScore GO #####
 ############################
-tmp <-  fread(sprintf('%sPathway_GO_scores.txt', inputFold), header = T, stringsAsFactors = F, sep = '\t', check.names = F, data.table = F)
-pathScoreID_GO <- tmp[,1]
-tmp <- tmp[,-1]
-identical(colnames(tmp), samplesID_new) # same order samples
-pathScore_GO <- as.matrix(t(tmp))
-rm(tmp)
+if (!is.null(GOterms_file)) {
+  tmp <-  fread(sprintf('%sPathway_GO_scores.txt', inputFold), header = T, stringsAsFactors = F, sep = '\t', check.names = F, data.table = F)
+  pathScoreID_GO <- tmp[,1]
+  tmp <- tmp[,-1]
+  identical(colnames(tmp), samplesID_new) # same order samples
+  pathScore_GO <- as.matrix(t(tmp))
+  rm(tmp)
 
-# consider only pathaways that do not heave gene repetition, on pathwayScoreID add gene info
-go <- get(load(GOterms_file))
+  # consider only pathaways that do not heave gene repetition, on pathwayScoreID add gene info
+  go <- get(load(GOterms_file))
 
-go_name <- sapply(go, function(x) x$GOID)
-go <- go[which(go_name %in% pathScoreID_GO)]
-go_name <- sapply(go, function(x) x$GOID)
-go_path_name <- sapply(go, function(x) x$Term)
-go_ont_name <- sapply(go, function(x) x$Ontology)
-identical(go_name, pathScoreID_GO)
-
-genes_path <- lapply(go, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x$geneIds])
-ngenes_path <-  sapply(go, function(x) length(unique(x$geneIds[x$geneIds != ""])))
-ngenes_tscore_path <- sapply(genes_path, length)
-
-# remove pathway with the same genes, recompute qvalue
-rm_path <- c()
-len <- c()
-for(i in 1:length(genes_path)){
-  # print(i)
-  id <- which(sapply(genes_path, function(x) all(genes_path[[i]] %in% x) & all(x %in% genes_path[[i]])))
-  len[i] <- length(id)
-  ngenes_tmp <- ngenes_path[id]
-  # take the one woth the lower amount of genes
-  rm_path <- c(rm_path, go_name[id][-which.min(ngenes_tmp)])
-}
-
-rm_path <- unique(rm_path)
-id_rm <- which(pathScoreID_GO %in% rm_path)
-if(length(id_rm)>0){
-  pathScore_GO <- pathScore_GO[,-id_rm]
-  pathScoreID_GO <- pathScoreID_GO[-id_rm]
-  go <- go[-id_rm]
+  go_name <- sapply(go, function(x) x$GOID)
+  go <- go[which(go_name %in% pathScoreID_GO)]
   go_name <- sapply(go, function(x) x$GOID)
   go_path_name <- sapply(go, function(x) x$Term)
   go_ont_name <- sapply(go, function(x) x$Ontology)
   identical(go_name, pathScoreID_GO)
+
   genes_path <- lapply(go, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x$geneIds])
-  ngenes_path <- ngenes_path[-id_rm]
-  ngenes_tscore_path <- ngenes_tscore_path[-id_rm]
-}
+  ngenes_path <-  sapply(go, function(x) length(unique(x$geneIds[x$geneIds != ""])))
+  ngenes_tscore_path <- sapply(genes_path, length)
 
-# add number of genes info and mean test_dev_geno and dev_geno
-df_pathGO_info <- data.frame(path_id = pathScoreID_GO, path = go_path_name, path_ont = go_ont_name, ngenes_tscore = unname(ngenes_tscore_path), ngenes_path = unname(ngenes_path), stringsAsFactors = F)
-df_pathGO_info$mean_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathGO_info$sd_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathGO_info$mean_test_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
-df_pathGO_info$sd_test_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
-
-# compute mean/sd correlation for the genes belonging to the pathway (based on tscore)
-df_pathGO_info$mean_gene_corr <- NA
-df_pathGO_info$sd_gene_corr <- NA
-
-for(i in 1:length(genes_path)){
-  
-  id <- which(genesID %in% genes_path[[i]])
-  
-  if(length(id)>1){
+  # remove pathway with the same genes, recompute qvalue
+  rm_path <- c()
+  len <- c()
+  for(i in 1:length(genes_path)){
     # print(i)
-    tmp <- cor(tscoreMat[,id])
-    tmp <- tmp[lower.tri(tmp, diag = F)]
-    df_pathGO_info$mean_gene_corr[i] <- mean(tmp)
-    df_pathGO_info$sd_gene_corr[i] <- sd(tmp)  
+    id <- which(sapply(genes_path, function(x) all(genes_path[[i]] %in% x) & all(x %in% genes_path[[i]])))
+    len[i] <- length(id)
+    ngenes_tmp <- ngenes_path[id]
+    # take the one woth the lower amount of genes
+    rm_path <- c(rm_path, go_name[id][-which.min(ngenes_tmp)])
   }
-  
-}
 
-print('pathScore GO mat loaded')
+  rm_path <- unique(rm_path)
+  id_rm <- which(pathScoreID_GO %in% rm_path)
+  if(length(id_rm)>0){
+    pathScore_GO <- pathScore_GO[,-id_rm]
+    pathScoreID_GO <- pathScoreID_GO[-id_rm]
+    go <- go[-id_rm]
+    go_name <- sapply(go, function(x) x$GOID)
+    go_path_name <- sapply(go, function(x) x$Term)
+    go_ont_name <- sapply(go, function(x) x$Ontology)
+    identical(go_name, pathScoreID_GO)
+    genes_path <- lapply(go, function(x) geneAnn$external_gene_name[geneAnn$external_gene_name %in% x$geneIds])
+    ngenes_path <- ngenes_path[-id_rm]
+    ngenes_tscore_path <- ngenes_tscore_path[-id_rm]
+  }
+
+  # add number of genes info and mean test_dev_geno and dev_geno
+  df_pathGO_info <- data.frame(path_id = pathScoreID_GO, path = go_path_name, path_ont = go_ont_name, ngenes_tscore = unname(ngenes_tscore_path), ngenes_path = unname(ngenes_path), stringsAsFactors = F)
+  df_pathGO_info$mean_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathGO_info$sd_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathGO_info$mean_test_dev_geno <- unname(sapply(genes_path, function(x) mean(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
+  df_pathGO_info$sd_test_dev_geno <- unname(sapply(genes_path, function(x) sd(geneAnn$test_dev_geno[geneAnn$external_gene_name %in% x])))
+
+  # compute mean/sd correlation for the genes belonging to the pathway (based on tscore)
+  df_pathGO_info$mean_gene_corr <- NA
+  df_pathGO_info$sd_gene_corr <- NA
+
+  for(i in 1:length(genes_path)){
+
+    id <- which(genesID %in% genes_path[[i]])
+
+    if(length(id)>1){
+      # print(i)
+      tmp <- cor(tscoreMat[,id])
+      tmp <- tmp[lower.tri(tmp, diag = F)]
+      df_pathGO_info$mean_gene_corr[i] <- mean(tmp)
+      df_pathGO_info$sd_gene_corr[i] <- sd(tmp)
+    }
+
+  }
+
+  print('pathScore GO mat loaded')
+}
 
 #### load phenotype annotation ####
 phenoAnn <- fread(file = phenoAnn_file, header = T, stringsAsFactors = F, data.table = F)
@@ -386,108 +390,113 @@ for(n in 1:length(phenoDat_file)){
   ########################################
   #### pathScore Reactome assocaition ####
   ########################################
-  
-  pathScore_r_association <- cbind(pathScore_reactome[id_samples, ], tot_var)
-  colnames(pathScore_r_association)[1:length(pathScoreID_reactome)] <- paste0('X',1:length(pathScoreID_reactome))
-  
-  df_corr_pathR <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
-  info_pathR <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
-  
-  for(j in 1:nrow(phenoAnn_tmp)){
-    
-    print(paste0('## phenotype ', phenoAnn_tmp$pheno_id[j], ' ##'))
-    
-    if(ncores>0){
-      # parallelize over genes
-      output <- foreach(x=1:nrow(df_pathR_info), .combine = rbind)%dopar%{
-        # print(x)
-        compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_r_association)
-      }   
-    }else{
-      output <- matrix(nrow = nrow(df_pathR_info), ncol = 4)
-      for(x in 1:nrow(df_pathR_info)){
-        # print(x)
-        output[x,] <- compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_r_association)
+  if (!is.null(reactome_file)) {
+    pathScore_r_association <- cbind(pathScore_reactome[id_samples, ], tot_var)
+    colnames(pathScore_r_association)[1:length(pathScoreID_reactome)] <- paste0('X',1:length(pathScoreID_reactome))
+
+    df_corr_pathR <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
+    info_pathR <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
+
+    for(j in 1:nrow(phenoAnn_tmp)){
+
+      print(paste0('## phenotype ', phenoAnn_tmp$pheno_id[j], ' ##'))
+
+      if(ncores>0){
+        # parallelize over genes
+        output <- foreach(x=1:nrow(df_pathR_info), .combine = rbind)%dopar%{
+          # print(x)
+          compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_r_association)
+        }
+      }else{
+        output <- matrix(nrow = nrow(df_pathR_info), ncol = 4)
+        for(x in 1:nrow(df_pathR_info)){
+          # print(x)
+          output[x,] <- compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_r_association)
+        }
       }
+
+      colnames(output) <- names_df[j,]
+      rownames(output) <- NULL
+      df_corr_pathR[[j]] <- cbind(df_pathR_info, output)
+
+      # qvalue:
+      qval <- qvalue(as.vector(df_corr_pathR[[j]][, names_df[j,4]]))
+      df_corr_pathR[[j]] <- cbind(df_corr_pathR[[j]], qval$qvalue)
+      colnames(df_corr_pathR[[j]])[ncol(df_corr_pathR[[j]])] <-  names_df_qval[j]
+      df_pi1$pathScore_reactome[j] <- 1 - qval$pi0
+
+      # create list object for each pathway with tscore association results
+      info_pathR[[j]] <- vector(mode = 'list', length = nrow(df_pathR_info))
+      for(x in 1:nrow(df_pathR_info)){
+
+        tmp <- gs[which(sapply(gs, function(x) x@reference) == df_pathR_info$path[x])]
+        info_pathR[[j]][[x]] <- list(path = df_corr_pathR[[j]][x,], genes_path = tmp[[1]]@ids, tscore = df_corr_tscore[[j]][df_corr_tscore[[j]]$external_gene_name %in% tmp[[1]]@ids,])
+
+      }
+
     }
-    
-    colnames(output) <- names_df[j,]
-    rownames(output) <- NULL
-    df_corr_pathR[[j]] <- cbind(df_pathR_info, output)
-    
-    # qvalue:
-    qval <- qvalue(as.vector(df_corr_pathR[[j]][, names_df[j,4]]))
-    df_corr_pathR[[j]] <- cbind(df_corr_pathR[[j]], qval$qvalue)
-    colnames(df_corr_pathR[[j]])[ncol(df_corr_pathR[[j]])] <-  names_df_qval[j]
-    df_pi1$pathScore_reactome[j] <- 1 - qval$pi0
-    
-    # create list object for each pathway with tscore association results
-    info_pathR[[j]] <- vector(mode = 'list', length = nrow(df_pathR_info))
-    for(x in 1:nrow(df_pathR_info)){
-      
-      tmp <- gs[which(sapply(gs, function(x) x@reference) == df_pathR_info$path[x])]
-      info_pathR[[j]][[x]] <- list(path = df_corr_pathR[[j]][x,], genes_path = tmp[[1]]@ids, tscore = df_corr_tscore[[j]][df_corr_tscore[[j]]$external_gene_name %in% tmp[[1]]@ids,])
-      
-    }
-    
+
+    rm(pathScore_r_association)
+    print('pathScore reactome completed')
+  } else {
+    df_corr_pathR <- data.frame()
   }
-  
-  rm(pathScore_r_association)
-  print('pathScore reactome completed')
-  
   
   ##################################
   #### pathScore GO assocaition ####
   ##################################
-  
-  pathScore_GO_association <- cbind(pathScore_GO[id_samples, ], tot_var)
-  colnames(pathScore_GO_association)[1:length(pathScoreID_GO)] <- paste0('X',1:length(pathScoreID_GO))
-  
-  df_corr_pathGO <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
-  info_pathGO <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
-  
-  for(j in 1:nrow(phenoAnn_tmp)){
-    
-    print(paste0('## phenotype ', phenoAnn_tmp$pheno_id[j], ' ##'))
-    
-    if(ncores>0){
-      # parallelize over genes
-      output <- foreach(x=1:nrow(df_pathGO_info), .combine = rbind)%dopar%{
-        # print(x)
-        compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_GO_association)
-      }   
-    }else{
-      output <- matrix(nrow = nrow(df_pathGO_info), ncol = 4)
+  if (!is.null(reactome_file)) {
+    pathScore_GO_association <- cbind(pathScore_GO[id_samples, ], tot_var)
+    colnames(pathScore_GO_association)[1:length(pathScoreID_GO)] <- paste0('X',1:length(pathScoreID_GO))
+
+    df_corr_pathGO <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
+    info_pathGO <- vector(mode = 'list', length = nrow(phenoAnn_tmp))
+
+    for(j in 1:nrow(phenoAnn_tmp)){
+
+      print(paste0('## phenotype ', phenoAnn_tmp$pheno_id[j], ' ##'))
+
+      if(ncores>0){
+        # parallelize over genes
+        output <- foreach(x=1:nrow(df_pathGO_info), .combine = rbind)%dopar%{
+          # print(x)
+          compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_GO_association)
+        }
+      }else{
+        output <- matrix(nrow = nrow(df_pathGO_info), ncol = 4)
+        for(x in 1:nrow(df_pathGO_info)){
+          # print(x)
+          output[x,] <- compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_GO_association)
+        }
+      }
+
+      colnames(output) <- names_df[j,]
+      rownames(output) <- NULL
+      df_corr_pathGO[[j]] <- cbind(df_pathGO_info, output)
+
+      # qvalue:
+      qval <- qvalue(as.vector(df_corr_pathGO[[j]][, names_df[j,4]]))
+      df_corr_pathGO[[j]] <- cbind(df_corr_pathGO[[j]], qval$qvalue)
+      colnames(df_corr_pathGO[[j]])[ncol(df_corr_pathGO[[j]])] <-  names_df_qval[j]
+      df_pi1$pathScore_GO[j] <- 1 - qval$pi0
+
+      # create list object for each pathway with tscore association results
+      # create list object for each pathway with tscore association results
+      info_pathGO[[j]] <- vector(mode = 'list', length = nrow(df_pathGO_info))
       for(x in 1:nrow(df_pathGO_info)){
-        # print(x)
-        output[x,] <- compute_reg_pheno(id_gene = x, type_pheno = phenoAnn_tmp$transformed_type[j], id_pheno = phenoAnn_tmp$pheno_id[j], total_mat = pathScore_GO_association)
+
+        tmp <- go[which(sapply(go, function(x) x$GOID) == df_pathGO_info$path_id[x])]
+        info_pathGO[[j]][[x]] <- list(path = df_corr_pathGO[[j]][x,], genes_path = tmp[[1]]$geneIds, tscore = df_corr_tscore[[j]][df_corr_tscore[[j]]$external_gene_name %in% tmp[[1]]$geneIds,])
+
       }
     }
-    
-    colnames(output) <- names_df[j,]
-    rownames(output) <- NULL
-    df_corr_pathGO[[j]] <- cbind(df_pathGO_info, output)
-    
-    # qvalue:
-    qval <- qvalue(as.vector(df_corr_pathGO[[j]][, names_df[j,4]]))
-    df_corr_pathGO[[j]] <- cbind(df_corr_pathGO[[j]], qval$qvalue)
-    colnames(df_corr_pathGO[[j]])[ncol(df_corr_pathGO[[j]])] <-  names_df_qval[j]
-    df_pi1$pathScore_GO[j] <- 1 - qval$pi0
-    
-    # create list object for each pathway with tscore association results
-    # create list object for each pathway with tscore association results
-    info_pathGO[[j]] <- vector(mode = 'list', length = nrow(df_pathGO_info))
-    for(x in 1:nrow(df_pathGO_info)){
-      
-      tmp <- go[which(sapply(go, function(x) x$GOID) == df_pathGO_info$path_id[x])]
-      info_pathGO[[j]][[x]] <- list(path = df_corr_pathGO[[j]][x,], genes_path = tmp[[1]]$geneIds, tscore = df_corr_tscore[[j]][df_corr_tscore[[j]]$external_gene_name %in% tmp[[1]]$geneIds,])
-      
-    }
+
+    rm(pathScore_GO_association)
+    print('pathScore go completed')
+  } else {
+    df_corr_pathGO <- data.frame()
   }
-  
-  rm(pathScore_GO_association)
-  print('pathScore go completed')
-  
+
   ################################################################################################################################################################################
   
   final <- list(pheno = phenoAnn[phenoAnn$pheno_id %in% pheno_names, ], tscore = df_corr_tscore, pathScore_reactome = df_corr_pathR, pathScore_GO = df_corr_pathGO, pi1 = df_pi1, 

--- a/Software/model_training/PriLer_part1_run.R
+++ b/Software/model_training/PriLer_part1_run.R
@@ -169,9 +169,9 @@ for(k in 1:nfolds_out){
   
 }
 
-predTest_geno_comb <- lapply(1:nfolds_out, function(x) as.matrix(t(betaSnpsMatrix[[k]]) %*% t(genDat[Folds[[x]],])))
+predTest_geno_comb <- lapply(1:nfolds_out, function(x) as.matrix(t(betaSnpsMatrix[[x]]) %*% t(genDat[Folds[[x]],])))
 predTest_geno_comb <- do.call(cbind, predTest_geno_comb)
-predTest_cov_comb <- lapply(1:nfolds_out, function(x) as.matrix(t(betaCovMatrix[[k]]) %*% t(cbind(covDat[Folds[[x]],], rep(1,length(Folds[[x]]))))))
+predTest_cov_comb <- lapply(1:nfolds_out, function(x) as.matrix(t(betaCovMatrix[[x]]) %*% t(cbind(covDat[Folds[[x]],], rep(1,length(Folds[[x]]))))))
 
 adjExpTest_comb <- lapply(1:nfolds_out, function(x) t(expDat[Folds[[x]],]) - predTest_cov_comb[[x]])
 adjExpTest_comb <- do.call(cbind, adjExpTest_comb)


### PR DESCRIPTION
Make pathway scores computation optional. This affects the association testing workflow starting from the T-scores/pathway scores computation script, association testing and meta-analysis.