### PR TITLE
Improve clustering workflow

### DIFF
--- a/Software/model_clustering/cluster_PGmethod_corrPCs_run.R
+++ b/Software/model_clustering/cluster_PGmethod_corrPCs_run.R
@@ -32,7 +32,7 @@ parser$add_argument("--split_tot", type = "integer", default = 0, help = "if 0 t
 parser$add_argument("--pvalresFile", type = "character", help = "file with pvalue results")
 parser$add_argument("--pval_id", type = "integer", default = 1, help = "id to be used on pvalue file")
 parser$add_argument("--pval_thr", type = "double", default = 1, help = "threshold to filter features")
-parser$add_argument("--corr_thr", type = "double", default = -1, help = "correlation among features threshold")
+parser$add_argument("--corr_thr", type = "double", default = 0.5, help = "correlation among features threshold")
 parser$add_argument("--functR", type = "character", help = "functions to be used")
 parser$add_argument("--type_data", type = "character", default = "tscore", help = "tscore, path_Reactome or path_GO")
 parser$add_argument("--type_sim", type = "character", default = 'HK', help = "HK or ED")

--- a/Software/model_clustering/cluster_PGmethod_corrPCs_run.R
+++ b/Software/model_clustering/cluster_PGmethod_corrPCs_run.R
@@ -372,34 +372,34 @@ p <- facet(p, facet.by = "PC", short.panel.labs = T, scales = 'free_y', nrow = 1
 ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_PCs.png', outFold, type_data, type_input, type_cluster, type_sim), width = 13, height = 4, plot = p, device = 'png')
 ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_PCs.pdf', outFold, type_data, type_input, type_cluster, type_sim), width = 13, height = 4, plot = p, device = 'pdf')
 
-# plot distribution AGE, Sex
-df_cov_age <- data.frame(Age = df_cov$Age, gr = df_cov$gr)
-output$test_cov$pval[output$test_cov$cov_id == 'Age'] <- kruskal.test(df_cov_age$Age, g = df_cov_age$gr)$p.value
+# plot distribution AGE, Sex if the information is available
+if ("Age" %in% colnames(df_cov) & "Gender" %in% colnames(df_cov)) {
+  df_cov_age <- data.frame(Age = df_cov$Age, gr = df_cov$gr)
+  output$test_cov$pval[output$test_cov$cov_id == 'Age'] <- kruskal.test(df_cov_age$Age, g = df_cov_age$gr)$p.value
 
-df_cov_sex <- data.frame(n = as.vector(table(df_cov$Gender, df_cov$gr)), Sex = rep(c('male', 'female'), P), gr = unlist(lapply(paste0('gr', 1:P), function(x) rep(x, 2))))
-df_cov_sex$Sex <- factor(df_cov_sex$Sex, levels = c('male', 'female'))
+  df_cov_sex <- data.frame(n = as.vector(table(df_cov$Gender, df_cov$gr)), Sex = rep(c('male', 'female'), P), gr = unlist(lapply(paste0('gr', 1:P), function(x) rep(x, 2))))
+  df_cov_sex$Sex <- factor(df_cov_sex$Sex, levels = c('male', 'female'))
 
-pl_a <- ggplot(df_cov_age, aes(x = gr, y = Age, fill = gr))+
-  geom_violin(alpha = 0.8)+
-  geom_boxplot(width=0.2, fill="white")+
-  xlab('')+ ylab('Age')+
-  scale_fill_manual(values = gr_color)+
-  annotate("text", x = 1, y = max(df_cov_age$Age)+2, 
-	label = sprintf('p=%s',	as.character(round(output$test_cov$pval[output$test_cov$cov_id == 'Age'], digits = 2))))+
-  theme_bw()+theme(legend.position = 'none')
+  pl_a <- ggplot(df_cov_age, aes(x = gr, y = Age, fill = gr))+
+    geom_violin(alpha = 0.8)+
+    geom_boxplot(width=0.2, fill="white")+
+    xlab('')+ ylab('Age')+
+    scale_fill_manual(values = gr_color)+
+    annotate("text", x = 1, y = max(df_cov_age$Age)+2,
+      label = sprintf('p=%s',	as.character(round(output$test_cov$pval[output$test_cov$cov_id == 'Age'], digits = 2))))+
+    theme_bw()+theme(legend.position = 'none')
 
-pl_s <- ggplot(df_cov_sex, aes(x = gr, y = n, color = gr, fill = Sex))+
-  geom_bar(size = 1, alpha = 0.8, stat = 'identity', position = position_dodge())+
-  xlab('')+ ylab('number of individual')+
-  scale_color_manual(values = gr_color)+
-  scale_fill_manual(values = c('grey10', 'grey60'))+
-  guides(color = FALSE)+
-  annotate("text", x = 1, y = max(df_cov_sex$n)+2, 
-	label = sprintf('p=%s', as.character(round(output$test_cov$pval[output$test_cov$cov_id == 'Gender'], digits = 2))))+
-  theme_bw()+theme(legend.position = 'right')
+  pl_s <- ggplot(df_cov_sex, aes(x = gr, y = n, color = gr, fill = Sex))+
+    geom_bar(size = 1, alpha = 0.8, stat = 'identity', position = position_dodge())+
+    xlab('')+ ylab('number of individual')+
+    scale_color_manual(values = gr_color)+
+    scale_fill_manual(values = c('grey10', 'grey60'))+
+    guides(color = FALSE)+
+    annotate("text", x = 1, y = max(df_cov_sex$n)+2,
+      label = sprintf('p=%s', as.character(round(output$test_cov$pval[output$test_cov$cov_id == 'Gender'], digits = 2))))+
+    theme_bw()+theme(legend.position = 'right')
 
-tot_pl <- ggarrange(plotlist = list(pl_a, pl_s), ncol = 2, nrow = 1, align='h', widths=c(1, 1.4))
-ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_Age_Sex.png', outFold, type_data, type_input, type_cluster, type_sim), width = 6.5, height = 3, plot = tot_pl, device = 'png')
-ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_Age_Sex.pdf', outFold, type_data, type_input, type_cluster, type_sim), width = 6.5, height = 3, plot = tot_pl, device = 'pdf')
-
-
+  tot_pl <- ggarrange(plotlist = list(pl_a, pl_s), ncol = 2, nrow = 1, align='h', widths=c(1, 1.4))
+  ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_Age_Sex.png', outFold, type_data, type_input, type_cluster, type_sim), width = 6.5, height = 3, plot = tot_pl, device = 'png')
+  ggsave(filename = sprintf('%s%s_corrPCs_%s_cluster%s_PGmethod_%smetric_Age_Sex.pdf', outFold, type_data, type_input, type_cluster, type_sim), width = 6.5, height = 3, plot = tot_pl, device = 'pdf')
+}

--- a/Software/model_prediction/Tscore_PathScore_diff_run.R
+++ b/Software/model_prediction/Tscore_PathScore_diff_run.R
@@ -376,61 +376,7 @@ if (!is.null(reactome_file)) {
   output2 = data.frame(rownames(scores),pvalues)
   names(output2) = c("pathID",colnames(pvalues))
   write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)
-  write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
-  scorecards[[curComparison]] = output
-
-  sigScores = scores; #sigScores[pvalues>0.005] = NA
-  if(any(sampleAnn$Dx == 1)){
-
-    cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
-    pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
-    # save
-    write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))),
-                file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-  }
-
-  controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
-  pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
-  # save
-  write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))),
-              file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-
-
-
-
-  if(any(sampleAnn$Dx == 1)){
-
-    thres=0.05
-    rAll=rowSums(pvalues<=thres)
-    rCase=rowSums(pvalues[,cases]<=thres)
-    rFrac=rCase/rAll
-    ind=!is.nan(rFrac)
-    pEn=cbind(rAll,rCase,rFrac)
-
-    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-                sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
-
-    padj=apply(pvalues,2,function(X){
-      return(qvalue(X)$qvalue)
-    })
-
-    #find gene sets that show high deviation
-    thres=0.05
-    rAll=rowSums(padj<=thres)
-    rCase=rowSums(padj[,cases]<=thres)
-    # rAll=rowSums(pvalues<=thres)
-    # rCase=rowSums(pvalues[,cases]<=thres)
-
-
-    rFrac=rCase/rAll
-    ind=!is.nan(rFrac)
-    pEn=cbind(rAll,rCase,rFrac)
-
-    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-                sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
-
-
-  }
+  #write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
 }
 
 ################################################
@@ -482,56 +428,5 @@ if (!is.null(GOterms_file)) {
   output2 = data.frame(rownames(scores),pvalues)
   names(output2) = c("pathID",colnames(pvalues))
   write.table(output,sprintf("%sPathway_%s_scores.txt", outFold, geneSetName),sep="\t",quote=F,row.names=F)
-  write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
-  scorecards[[curComparison]] = output
-
-  sigScores = scores; #sigScores[pvalues>0.005] = NA
-  if(any(sampleAnn$Dx == 1)){
-
-    cases=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==1,1]) ## mod LT
-    pvalCombined = apply(pvalues[,cases],1,function(X) { pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE) })
-    # save
-    write.table(x = data.frame(chisq = sort(pvalCombined), pathway = names(sort(pvalCombined))),
-                file = sprintf('%sPathwaySummaryPvalues_cases_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-  }
-
-  controls=is.element(colnames(scores),sampleAnn[sampleAnn$Dx==0,1]) ## mod LT
-  pvalCombined_controls = apply(pvalues[,controls],1,function(X) {pchisq(-2*sum(log(X)),2*length(X),lower.tail=FALSE)})
-  # save
-  write.table(x = data.frame(chisq = sort(pvalCombined_controls), pathway = names(sort(pvalCombined_controls))),
-              file = sprintf('%sPathwaySummaryPvalues_controls_%s.txt', outFold, geneSetName), sep = '\t', quote = F, col.names = T, row.names = F)
-
-
-
-  if(any(sampleAnn$Dx == 1)){
-
-    thres=0.05
-    rAll=rowSums(pvalues<=thres)
-    rCase=rowSums(pvalues[,cases]<=thres)
-    rFrac=rCase/rAll
-    ind=!is.nan(rFrac)
-    pEn=cbind(rAll,rCase,rFrac)
-
-    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-                sprintf("%sPathwayEnrichment_%s_FracCases.txt", outFold, geneSetName),sep="\t",quote=F, row.names = F)
-
-    padj=apply(pvalues,2,function(X){
-      return(qvalue(X)$qvalue)
-    })
-
-    #find gene sets that show high deviation
-    thres=0.05
-    rAll=rowSums(padj<=thres)
-    rCase=rowSums(padj[,cases]<=thres)
-    # rAll=rowSums(pvalues<=thres)
-    # rCase=rowSums(pvalues[,cases]<=thres)
-
-
-    rFrac=rCase/rAll
-    ind=!is.nan(rFrac)
-    pEn=cbind(rAll,rCase,rFrac)
-
-    write.table(data.frame(cbind(pathway=rownames(pEn[ind,]), pEn[ind,])),
-                sprintf("%sPathwayEnrichment_%s_FracCases_pvalAdj.txt",outFold, geneSetName),sep="\t",quote=F, row.names = F)
-  }
+  #write.table(output2,sprintf("%sPathway_%s_pval.txt", outFold,geneSetName),sep="\t",quote=F,row.names=F)
 }

--- a/Software/model_prediction/formatGenotypeDosage.R
+++ b/Software/model_prediction/formatGenotypeDosage.R
@@ -9,9 +9,9 @@ suppressPackageStartupMessages({
 parser <- argparse::ArgumentParser()
 
 parser$add_argument(
-  "--genFile",
+  "--trawFile",
   type = "character",
-  help = "Full path to the genotype files until \"chr\""
+  help = "Full path to the traw files until \"chr\""
 )
 
 parser$add_argument(
@@ -27,36 +27,20 @@ parser$add_argument(
   help = "Folder to save dosage files"
 )
 
-
 args <- parser$parse_args()
 
-
-gen_name <- basename(args$genFile)
-
+gen_name <- basename(args$trawFile)
 
 for (chr in 1:22) {
-  gen_file <- data.table::fread(sprintf("%schr%s.gen.gz", args$genFile, chr), header = FALSE)
+  gen_file <- data.table::fread(sprintf("%schr%s.traw", args$trawFile, chr), header = FALSE)
 
-  sample_file <- read.table(
-    sprintf("%schr%s.sample", args$genFile, chr),
-    stringsAsFactors = FALSE,
-    row.names = NULL
-  )
-
-
-  gen_file <- gen_file[, 6:ncol(gen_file)]
-
-  gen_file <- gen_file[, seq(3, ncol(gen_file), 3), with = FALSE] * 2 +
-              gen_file[, seq(2, ncol(gen_file), 3), with = FALSE]
+  gen_file <- gen_file[, 7:ncol(gen_file)]
 
   gen_file <- round(gen_file, 2)
 
   gen_file[gen_file < args$dosageThresh] <- 0
 
-  colnames(gen_file) <- sample_file$V2[3:nrow(sample_file)]
-
-
-  out_name <- sprintf("%s/%sdosage_chr%s_matrix.txt.gz", args$outDosageFold, gen_name, chr)
+  out_name <- sprintf("%s/%schr%s_matrix.txt.gz", args$outDosageFold, gen_name, chr)
 
   data.table::fwrite(gen_file, out_name, sep = "\t", compress = "gzip")
 }

--- a/Software/model_prediction/formatGenotypeDosage.R
+++ b/Software/model_prediction/formatGenotypeDosage.R
@@ -24,6 +24,7 @@ parser$add_argument(
 parser$add_argument(
   "--outDosageFold",
   type = "character",
+  default = ".",
   help = "Folder to save dosage files"
 )
 

--- a/Software/model_prediction/formatGenotypeDosage.R
+++ b/Software/model_prediction/formatGenotypeDosage.R
@@ -17,14 +17,14 @@ parser$add_argument(
 parser$add_argument(
   "--sampleFile",
   type = "character",
-  help = "Full path to the sample file, including the suffix."
+  help = "Full path to the sample file, including the suffix"
 )
 
 parser$add_argument(
   "--sampleNameColumn",
   type = "integer",
-  default = 1,
-  help = "Which column in the sample file to use for column names."
+  default = NULL,
+  help = "Which column in the sample file to use for column names. Default is a concatentaion of FID (1) and IID (2)"
 )
 
 parser$add_argument(
@@ -56,7 +56,11 @@ for (chr in 1:22) {
 
   gen_file <- round(gen_file, 2)
 
-  colnames(gen_file) <- sample_file[[args$sampleNameColumn]]
+  if (is.null(args$sampleNameColumn)) {
+    colnames(gen_file) <- paste(sample_file[[1]], sample_file[[2]], sep = "_")
+  } else {
+    colnames(gen_file) <- sample_file[[args$sampleNameColumn]]
+  }
 
   out_name <- sprintf("%s/%schr%s_matrix.txt.gz", args$outDosageFold, gen_name, chr)
 

--- a/Software/model_prediction/formatGenotypeDosage.R
+++ b/Software/model_prediction/formatGenotypeDosage.R
@@ -15,6 +15,19 @@ parser$add_argument(
 )
 
 parser$add_argument(
+  "--sampleFile",
+  type = "character",
+  help = "Full path to the sample file, including the suffix."
+)
+
+parser$add_argument(
+  "--sampleNameColumn",
+  type = "integer",
+  default = 1,
+  help = "Which column in the sample file to use for column names."
+)
+
+parser$add_argument(
   "--dosageThresh",
   type = "double",
   default = 0.1,
@@ -30,16 +43,20 @@ parser$add_argument(
 
 args <- parser$parse_args()
 
+sample_file <- read.delim(args$sampleFile, check.names = FALSE, stringsAsFactors = FALSE)
+
 gen_name <- basename(args$trawFile)
 
 for (chr in 1:22) {
   gen_file <- data.table::fread(sprintf("%schr%s.traw", args$trawFile, chr))
 
-  gen_file <- gen_file[, 7:ncol(gen_file)]
+  gen_file[, (1:6) := NULL]
+
+  gen_file[gen_file < args$dosageThresh] <- 0
 
   gen_file <- round(gen_file, 2)
 
-  gen_file[gen_file < args$dosageThresh] <- 0
+  colnames(gen_file) <- sample_file[[args$sampleNameColumn]]
 
   out_name <- sprintf("%s/%schr%s_matrix.txt.gz", args$outDosageFold, gen_name, chr)
 

--- a/Software/model_prediction/formatGenotypeDosage.R
+++ b/Software/model_prediction/formatGenotypeDosage.R
@@ -32,7 +32,7 @@ args <- parser$parse_args()
 gen_name <- basename(args$trawFile)
 
 for (chr in 1:22) {
-  gen_file <- data.table::fread(sprintf("%schr%s.traw", args$trawFile, chr), header = FALSE)
+  gen_file <- data.table::fread(sprintf("%schr%s.traw", args$trawFile, chr))
 
   gen_file <- gen_file[, 7:ncol(gen_file)]
 

--- a/Software/model_prediction/pheno_association_smallData_run.R
+++ b/Software/model_prediction/pheno_association_smallData_run.R
@@ -343,6 +343,7 @@ for(n in 1:length(phenoDat_file)){
   print(str(phenoAnn_tmp))
   names_df <- t(sapply(phenoAnn_tmp$pheno_id, function(x) paste0(x, c('_beta', '_se_beta','_z_t','_pval'))))
   names_df_qval <- sapply(phenoAnn_tmp$pheno_id, function(x) paste0(x, c('_qval')))
+  names_df_bhcorr <- sapply(phenoAnn_tmp$pheno_id, function(x) paste0(x, c('_BHcorr')))
   
   ############################
   #### tscore assocaition ####
@@ -390,7 +391,10 @@ for(n in 1:length(phenoDat_file)){
     df_corr_tscore[[j]] <- cbind(df_corr_tscore[[j]], qval$qvalue)
     colnames(df_corr_tscore[[j]])[ncol(df_corr_tscore[[j]])] <-  names_df_qval[j]
     df_pi1$tscore[j] <- 1 - qval$pi0
-    
+
+    BH_t <- p.adjust(as.vector(df_corr_tscore[[j]][, names_df[j,4]]), method = 'BH')
+    df_corr_tscore[[j]] <- cbind(df_corr_tscore[[j]], BH_t)
+    colnames(df_corr_tscore[[j]])[ncol(df_corr_tscore[[j]])] <-  names_df_bhcorr[j]
   }
   
   rm(tscoreMat_association)
@@ -433,6 +437,10 @@ for(n in 1:length(phenoDat_file)){
       df_corr_pathR[[j]] <- cbind(df_corr_pathR[[j]], qval$qvalue)
       colnames(df_corr_pathR[[j]])[ncol(df_corr_pathR[[j]])] <-  names_df_qval[j]
       df_pi1$pathScore_reactome[j] <- 1 - qval$pi0
+
+      BH_t <- p.adjust(as.vector(df_corr_pathR[[j]][, names_df[j,4]]), method = 'BH')
+      df_corr_pathR[[j]] <- cbind(df_corr_pathR[[j]], BH_t)
+      colnames(df_corr_pathR[[j]])[ncol(df_corr_pathR[[j]])] <- names_df_bhcorr[j]
 
       # create list object for each pathway with tscore association results
       info_pathR[[j]] <- vector(mode = 'list', length = nrow(df_pathR_info))
@@ -489,6 +497,10 @@ for(n in 1:length(phenoDat_file)){
       df_corr_pathGO[[j]] <- cbind(df_corr_pathGO[[j]], qval$qvalue)
       colnames(df_corr_pathGO[[j]])[ncol(df_corr_pathGO[[j]])] <-  names_df_qval[j]
       df_pi1$pathScore_GO[j] <- 1 - qval$pi0
+
+      BH_t <- p.adjust(as.vector(df_corr_pathGO[[j]][, names_df[j,4]]), method = 'BH')
+      df_corr_pathGO[[j]] <- cbind(df_corr_pathGO[[j]], BH_t)
+      colnames(df_corr_pathGO[[j]])[ncol(df_corr_pathGO[[j]])] <- names_df_bhcorr[j]
 
       # create list object for each pathway with tscore association results
       # create list object for each pathway with tscore association results


### PR DESCRIPTION
Various small fixes and improvements.
- Do not save pathway score statistics in Tscore_PathScore_diff_run.R, only scores
- In pheno_association_smallData_run.R, compute BH-corrected P-values in addition to q-values for compatibility with the clustering scripts
- In cluster_PGmethod_corrPCs_run.R, use more sensible default for correlation threshold (0.5)
- In cluster_PGmethod_corrPCs_run.R, make age and gender cluster-specific distribution plots only if both are available in the sample annotation file
- In cluster_PGmethod_PCs_run.R, add option to use only sample annotation file with PCs 
- Update the READMEs accordingly